### PR TITLE
Fix date-dependent data loading

### DIFF
--- a/src/composables/useStaticData.js
+++ b/src/composables/useStaticData.js
@@ -1,15 +1,17 @@
-import { ref } from 'vue';
+import { ref, unref } from 'vue';
 
-export function useStaticData(date) {
+// Accepts a ref to a date string so the composable can
+// load new data when the date value changes.
+export function useStaticData(dateRef) {
   const data = ref(null);
   const metadata = ref(null);
   const loading = ref(false);
   const error = ref(null);
   
-  async function load() {
-    console.log(`Loading data for date: ${date}`);
+  async function load(currentDate = unref(dateRef)) {
+    console.log(`Loading data for date: ${currentDate}`);
     
-    if (!date) {
+    if (!currentDate) {
       console.error('No date provided');
       error.value = 'No date provided';
       return;
@@ -23,8 +25,8 @@ export function useStaticData(date) {
       const base = import.meta.env.MODE === 'production' ? '/nyc-water-app' : '';
       
       // Build URLs with correct base path
-      const geojsonUrl = `${base}/data/${date}/enriched.geojson`;
-      const metadataUrl = `${base}/data/${date}/metadata.json`;
+      const geojsonUrl = `${base}/data/${currentDate}/enriched.geojson`;
+      const metadataUrl = `${base}/data/${currentDate}/metadata.json`;
       
       console.log(`Fetching from: ${geojsonUrl} and ${metadataUrl}`);
       

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -14,7 +14,8 @@ const isDarkMode = ref(false);
 const availableDates = ref(['2025-05-14', '2025-05-08']);
 
 // Use the static data composable
-const { data, metadata, loading, error, load } = useStaticData(date.value);
+// Pass the date ref so the composable can react to updates
+const { data, metadata, loading, error, load } = useStaticData(date);
 
 onMounted(async () => {
   // Load data for the current date
@@ -27,7 +28,7 @@ watch(() => route.params.date, (newDate) => {
   if (newDate && newDate !== date.value) {
     console.log('Route date changed:', newDate);
     date.value = newDate;
-    load();
+    load(newDate);
   }
 });
 
@@ -35,7 +36,7 @@ watch(() => route.params.date, (newDate) => {
 watch(date, (newDate) => {
   console.log('Date changed:', newDate);
   if (newDate) {
-    load();
+    load(newDate);
   }
 });
 


### PR DESCRIPTION
## Summary
- pass date ref to `useStaticData`
- update loaders to use current date

## Testing
- `npm install` *(fails: Exit handler never called)*