### PR TITLE
Default to dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An interactive web application to visualize water quality data across various sa
 - Historical data navigation with a date scroller
 - Detailed information for each sampling site
 - Mobile-friendly responsive design
-- Light and dark theme support
+- Light and dark theme support (defaults to dark)
 
 ## Technology Stack
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>NYC Water Quality</title>
     <meta name="description" content="Interactive map of NYC waterway quality samples">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#1f2937">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,11 @@ html, body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
+body.dark {
+  background-color: #1f2937; /* gray-800 */
+  color: #f3f4f6; /* gray-100 */
+}
+
 #app {
   height: 100%;
   width: 100%;

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -10,7 +10,13 @@ import { useStaticData } from '../composables/useStaticData';
 
 const route = useRoute();
 const date = ref(route.params.date);
-const isDarkMode = ref(false);
+const isDarkMode = ref(true);
+
+// Apply initial theme class to document
+if (typeof document !== 'undefined') {
+  document.documentElement.classList.toggle('dark', isDarkMode.value);
+  document.body.classList.toggle('dark', isDarkMode.value);
+}
 const availableDates = ref(['2025-05-14', '2025-05-08']);
 
 // Use the static data composable
@@ -37,6 +43,14 @@ watch(date, (newDate) => {
   console.log('Date changed:', newDate);
   if (newDate) {
     load(newDate);
+  }
+});
+
+// Watch for dark mode changes to update body class
+watch(isDarkMode, (val) => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.classList.toggle('dark', val);
+    document.body.classList.toggle('dark', val);
   }
 });
 


### PR DESCRIPTION
## Summary
- default the app to dark mode
- update meta theme color for dark theme
- apply dark class to document and body
- describe default dark theme in README

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network unreachable)*