### PR TITLE
Add Jest unit test for useStaticData

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+};

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "jest",
     "enrich": "node scripts/enrich-data.js",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
@@ -22,6 +23,10 @@
     "gh-pages": "^6.3.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@babel/core": "^7.22.20",
+    "@babel/preset-env": "^7.22.20"
   }
 }

--- a/tests/useStaticData.test.js
+++ b/tests/useStaticData.test.js
@@ -1,0 +1,52 @@
+import { ref } from 'vue';
+import { useStaticData } from '../src/composables/useStaticData';
+
+describe('useStaticData', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  test('loads data and metadata successfully', async () => {
+    const geojson = { features: [1, 2, 3] };
+    const meta = { updated: '2023-01-01' };
+
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(geojson) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(meta) });
+
+    const date = ref('2023-01-01');
+    const { data, metadata, loading, error, load } = useStaticData(date);
+
+    const promise = load();
+    expect(loading.value).toBe(true);
+    await promise;
+
+    expect(data.value).toEqual(geojson);
+    expect(metadata.value).toEqual(meta);
+    expect(error.value).toBe(null);
+    expect(loading.value).toBe(false);
+  });
+
+  test('handles fetch errors', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+    const date = ref('2023-02-01');
+    const { data, metadata, error, loading, load } = useStaticData(date);
+
+    await load();
+
+    expect(error.value).toMatch('Failed to fetch GeoJSON');
+    expect(data.value).toBe(null);
+    expect(metadata.value).toBe(null);
+    expect(loading.value).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- setup Jest with babel-jest
- add unit tests for `useStaticData`
- provide `npm test` script

## Testing
- `npm test` *(fails: jest not found)*