### PR TITLE
Reduce rainfall legend height

### DIFF
--- a/src/components/RainDropLegend.vue
+++ b/src/components/RainDropLegend.vue
@@ -6,7 +6,7 @@
   >
     <h3 class="text-xs font-medium mb-2">7-Day Rainfall</h3>
 
-    <div class="flex items-end justify-between h-28 mb-1">
+    <div class="flex items-end justify-between h-20 mb-1">
       <!-- 7 vertical bars representing daily rainfall -->
       <div
         v-for="(value, index) in activeRainData"


### PR DESCRIPTION
## Summary
- tweak RainDropLegend height so that the tallest day maxes out at 100%

## Testing
- `npm test` *(fails: jest not found)*