### PR TITLE
Fix meta tag for mobile app

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>NYC Water Quality</title>
     <meta name="description" content="Interactive map of NYC waterway quality samples">
     <meta name="theme-color" content="#1f2937">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
   </head>
   <body>


### PR DESCRIPTION
## Summary
- replace deprecated `apple-mobile-web-app-capable` meta tag with `mobile-web-app-capable`

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*
- `npm test` *(fails: jest not found)*