### PR TITLE
Clean up input CSVs after enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The application uses a static data approach for improved performance and reliabi
    - Place sample and rainfall CSV files in `scripts/input/`
    - Run `npm run enrich` to convert the CSV files to GeoJSON and generate metadata
      with rainfall and tide information pulled from NOAA
-   - Each dataset is stored in `public/data/<date>/` and the newest date is written to `latest.txt`
+    - Each dataset is stored in `public/data/<date>/` and the newest date is written to `latest.txt`
+    - Processed CSV files are removed from `scripts/input/` once enrichment succeeds
 
 2. **Data Files**:
    - **Source Data**: Raw CSV files in `scripts/input/`

--- a/scripts/enrich-data.js
+++ b/scripts/enrich-data.js
@@ -118,8 +118,17 @@ async function processDatasets() {
   
   for (const [date, files] of dateMap.entries()) {
     if (files.samples && files.rain) {
-      await processDateFiles(date, files.samples, files.rain);
-      processedDates++;
+      const success = await processDateFiles(date, files.samples, files.rain);
+      if (success) {
+        processedDates++;
+        try {
+          fs.unlinkSync(path.join(INPUT_DIR, files.samples));
+          fs.unlinkSync(path.join(INPUT_DIR, files.rain));
+          console.log(`🗑️  Removed input files for ${date}`);
+        } catch (err) {
+          console.warn(`⚠️  Could not delete input files for ${date}:`, err);
+        }
+      }
     } else {
       console.warn(`Incomplete data for ${date}: samples=${files.samples ? 'Yes' : 'No'}, rain=${files.rain ? 'Yes' : 'No'}`);
     }


### PR DESCRIPTION
## Summary
- delete processed CSV files from `scripts/input` when enrichment succeeds
- document automatic cleanup in README

## Testing
- `npm test` *(fails: jest not found)*