### PR TITLE
Update posthog-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "papaparse": "^5.5.2",
         "vue": "^3.4.0",
         "vue-router": "^4.2.5",
-        "posthog-js": "^2.4.2"
+        "posthog-js": "^3.0.0"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.0",
@@ -3285,8 +3285,8 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-2.4.2.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-3.0.0.tgz",
       "integrity": "",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "papaparse": "^5.5.2",
     "vue": "^3.4.0",
     "vue-router": "^4.2.5",
-    "posthog-js": "^2.4.2"
+    "posthog-js": "^3.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",


### PR DESCRIPTION
## Summary
- bump `posthog-js` from `^2.4.2` to `^3.0.0`

## Testing
- `npm run build` *(fails: `vite` not found)*