### PR TITLE
Add analytics for site clicks

### DIFF
--- a/src/components/MapViewer.vue
+++ b/src/components/MapViewer.vue
@@ -9,6 +9,7 @@
 import { ref, onMounted, watch, onUnmounted } from 'vue';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { track, EVENT_CLICK_SITE_MARKER } from '../services/analytics';
 
 // Constants for MPN threshold values
 const MPN_THRESHOLD_LOW = 35;
@@ -334,6 +335,10 @@ export default {
               className: props.isDarkMode ? 'dark-mode-popup' : '',
             })
             .addTo(map.value);
+
+          marker.on('click', () => {
+            track(EVENT_CLICK_SITE_MARKER, { site_name: siteName });
+          });
 
           markers.value.push(marker);
         } catch (error) {

--- a/src/services/analytics/index.js
+++ b/src/services/analytics/index.js
@@ -1,5 +1,7 @@
 import posthog from 'posthog-js';
 
+export const EVENT_CLICK_SITE_MARKER = 'click_site_marker';
+
 let isInitialized = false;
 
 export function initAnalytics() {


### PR DESCRIPTION
## Summary
- log when a map site marker is clicked

## Testing
- `npm test` *(fails: jest not found)*