### PR TITLE
Add 404 fallback for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The application is configured for deployment to GitHub Pages:
 npm run deploy
 ```
 
+The deploy script automatically copies `index.html` to `404.html` after building so that
+dynamic routes like `/2025-05-08` work when hosted on GitHub Pages.
+
 ## Analytics
 
 The application supports optional PostHog tracking. To enable analytics:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview",
     "test": "jest",
     "enrich": "node scripts/enrich-data.js",
-    "predeploy": "npm run build",
+    "predeploy": "npm run build && node scripts/copy-404.js",
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {

--- a/scripts/copy-404.js
+++ b/scripts/copy-404.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.resolve(__dirname, '../dist');
+const indexPath = path.join(distDir, 'index.html');
+const notFoundPath = path.join(distDir, '404.html');
+
+if (fs.existsSync(indexPath)) {
+  fs.copyFileSync(indexPath, notFoundPath);
+  console.log('404.html created for GitHub Pages routing');
+} else {
+  console.error('index.html not found. Did you run the build?');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- copy `index.html` to `404.html` during deployment
- run the copy script in the `predeploy` step
- document the 404 fallback in the README

## Testing
- `npm test` *(fails: jest not found)*