### PR TITLE
Add popup open tracking to PostHog

### DIFF
--- a/src/components/DataInfoPopup.vue
+++ b/src/components/DataInfoPopup.vue
@@ -70,6 +70,7 @@ import {
   track,
   EVENT_CLICK_DATA_INFO_BUTTON,
   EVENT_CLICK_OUTBOUND_LINK,
+  EVENT_OPEN_POPUP,
 } from '../services/analytics';
 
 export default {
@@ -87,6 +88,7 @@ export default {
       const wasClosed = !isOpen.value;
       baseToggle();
       if (wasClosed) {
+        track(EVENT_OPEN_POPUP, { component: 'DataInfoPopup' });
         track(EVENT_CLICK_DATA_INFO_BUTTON);
       }
     };

--- a/src/components/DonatePopup.vue
+++ b/src/components/DonatePopup.vue
@@ -54,7 +54,12 @@
 
 <script>
 import { usePopupManager } from '../composables/usePopupManager';
-import { track, EVENT_CLICK_DONATE_BUTTON, EVENT_CLICK_OUTBOUND_LINK } from '../services/analytics';
+import {
+  track,
+  EVENT_CLICK_DONATE_BUTTON,
+  EVENT_CLICK_OUTBOUND_LINK,
+  EVENT_OPEN_POPUP,
+} from '../services/analytics';
 
 export default {
   name: 'DonatePopup',
@@ -71,6 +76,7 @@ export default {
       const wasClosed = !isOpen.value;
       baseToggle();
       if (wasClosed) {
+        track(EVENT_OPEN_POPUP, { component: 'DonatePopup' });
         track(EVENT_CLICK_DONATE_BUTTON);
       }
     };

--- a/src/components/InfoPopup.vue
+++ b/src/components/InfoPopup.vue
@@ -55,6 +55,7 @@
 <script>
 import { onMounted } from 'vue';
 import { usePopupManager } from '../composables/usePopupManager';
+import { track, EVENT_OPEN_POPUP } from '../services/analytics';
 
 export default {
   name: 'InfoPopup',
@@ -65,12 +66,20 @@ export default {
     },
   },
   setup() {
-    const { isOpen, togglePopup } = usePopupManager('info');
+    const { isOpen, togglePopup: baseToggle } = usePopupManager('info');
+
+    const togglePopup = (trackEvent = true) => {
+      const wasClosed = !isOpen.value;
+      baseToggle();
+      if (wasClosed && trackEvent) {
+        track(EVENT_OPEN_POPUP, { component: 'InfoPopup' });
+      }
+    };
 
     onMounted(() => {
       try {
         if (!localStorage.getItem('hasSeenInfoPopup')) {
-          togglePopup();
+          togglePopup(false);
           localStorage.setItem('hasSeenInfoPopup', 'true');
         }
       } catch (e) {

--- a/src/services/analytics/index.js
+++ b/src/services/analytics/index.js
@@ -4,6 +4,7 @@ export const EVENT_CLICK_SITE_MARKER = 'click_site_marker';
 export const EVENT_CLICK_DATA_INFO_BUTTON = 'click_data_info_button';
 export const EVENT_CLICK_DONATE_BUTTON = 'click_donate_button';
 export const EVENT_CLICK_OUTBOUND_LINK = 'click_outbound_link';
+export const EVENT_OPEN_POPUP = 'open_popup';
 
 let isInitialized = false;
 


### PR DESCRIPTION
## Summary
- add `open_popup` event constant in analytics service
- track popup opens for `InfoPopup`, `DataInfoPopup` and `DonatePopup`

## Testing
- `npm test` *(fails: jest not found)*