### PR TITLE
Add data info alert for poor samples

### DIFF
--- a/src/components/DataInfoPopup.vue
+++ b/src/components/DataInfoPopup.vue
@@ -54,13 +54,17 @@
 
   <button
     :class="[
-      'fixed bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] left-1/2 transform -translate-x-1/2 ml-[-3rem] z-40 rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-colors duration-300',
+      'fixed bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] left-1/2 transform -translate-x-1/2 ml-[-3rem] z-40 rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-colors duration-300 relative',
       isDarkMode ? 'bg-gray-800 text-gray-200' : 'bg-white text-gray-800',
     ]"
     title="Data information"
     @click="togglePopup"
   >
     <span class="font-semibold text-lg">?</span>
+    <span
+      v-if="showNotification"
+      class="absolute top-1 right-1 w-3 h-3 bg-red-500 rounded-full"
+    ></span>
   </button>
 </template>
 
@@ -80,8 +84,12 @@ export default {
       type: Boolean,
       default: false,
     },
+    showNotification: {
+      type: Boolean,
+      default: false,
+    },
   },
-  setup() {
+  setup(props) {
     const { isOpen, togglePopup: baseToggle } = usePopupManager('data-info');
 
     const togglePopup = () => {
@@ -101,6 +109,7 @@ export default {
       isOpen,
       togglePopup,
       trackOutbound,
+      showNotification: props.showNotification,
     };
   },
 };

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import MapViewer from '../components/MapViewer.vue';
 import RainDropLegend from '../components/RainDropLegend.vue';
@@ -28,6 +28,19 @@ const availableDates = ref(['2025-05-08', '2025-05-15']);
 // Use the static data composable
 // Pass the date ref so the composable can react to updates
 const { data, metadata, loading, error, load } = useStaticData(date);
+
+// Calculate the percentage of samples testing poor for the week
+const poorPercentage = computed(() => {
+  if (!data.value || !Array.isArray(data.value.features)) return 0;
+  const total = data.value.features.length;
+  if (total === 0) return 0;
+  const poorCount = data.value.features.filter(
+    feature => Number(feature.properties.mpn) > 104
+  ).length;
+  return (poorCount / total) * 100;
+});
+
+const showDataInfoNotification = computed(() => poorPercentage.value > 25);
 
 onMounted(async () => {
   // Load data for the current date
@@ -99,7 +112,10 @@ const toggleDarkMode = () => {
 
       <!-- Info and action popups -->
       <InfoPopup :isDarkMode="isDarkMode" />
-      <DataInfoPopup :isDarkMode="isDarkMode" />
+      <DataInfoPopup
+        :isDarkMode="isDarkMode"
+        :showNotification="showDataInfoNotification"
+      />
       <DonatePopup :isDarkMode="isDarkMode" />
     </div>
 


### PR DESCRIPTION
## Summary
- compute percent of poor samples in `[date].vue`
- show a notification dot on `DataInfoPopup` when more than 25% of samples test poor

## Testing
- `npm test` *(fails: jest not found)*