### PR TITLE
Inject redirect date at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/inject-latest.js",
     "preview": "vite preview",
     "test": "jest",
     "enrich": "node scripts/enrich-data.js",

--- a/scripts/inject-latest.js
+++ b/scripts/inject-latest.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+// Paths
+const ROOT = path.resolve(__dirname, '..');
+const DIST_DIR = path.join(ROOT, 'dist');
+const PUBLIC_DIR = path.join(ROOT, 'public');
+const latestPath = path.join(PUBLIC_DIR, 'data', 'latest.txt');
+const indexPath = path.join(DIST_DIR, 'index.html');
+
+if (!fs.existsSync(latestPath)) {
+  console.error('latest.txt not found at', latestPath);
+  process.exit(1);
+}
+if (!fs.existsSync(indexPath)) {
+  console.error('index.html not found at', indexPath);
+  process.exit(1);
+}
+
+const latest = fs.readFileSync(latestPath, 'utf-8').trim();
+const base = process.env.NODE_ENV === 'production' ? '/nyc-water-app' : '';
+const redirectUrl = `${base}/${latest}/`;
+
+const html = fs.readFileSync(indexPath, 'utf-8');
+const metaTag = `<meta http-equiv="refresh" content="0; url=${redirectUrl}">`;
+const newHtml = html.replace(/<head>/i, `<head>\n    ${metaTag}`);
+fs.writeFileSync(indexPath, newHtml);
+console.log(`Injected redirect to ${redirectUrl} into index.html`);
+

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,48 +1,9 @@
 <script setup>
-import { ref, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
-
-const router = useRouter();
-const isLoading = ref(true);
-const error = ref(null);
-
-onMounted(async () => {
-  try {
-    console.log('Fetching latest date...');
-    // Get the base URL for GitHub Pages
-    const base = import.meta.env.MODE === 'production' ? '/nyc-water-app' : '';
-    const response = await fetch(`${base}/data/latest.txt`);
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch latest date: ${response.status}`);
-    }
-
-    const latest = await response.text();
-    const trimmedDate = latest.trim();
-    console.log('Latest date:', trimmedDate);
-
-    if (trimmedDate) {
-      router.push(`/${trimmedDate}`);
-    } else {
-      throw new Error('Empty date received');
-    }
-  } catch (err) {
-    console.error('Redirect error:', err);
-    error.value = err.message;
-  } finally {
-    isLoading.value = false;
-  }
-});
+// Redirect handled in index.html during production build
 </script>
 
 <template>
-  <div class="h-screen flex items-center justify-center flex-col">
-    <div v-if="isLoading" class="text-center text-lg">
-      <p>Redirecting to latest data...</p>
-    </div>
-    <div v-else-if="error" class="text-center text-red-500">
-      <p>Error: {{ error }}</p>
-      <p class="mt-2 text-sm">Try accessing a specific date directly, e.g., /2025-05-16</p>
-    </div>
+  <div class="h-screen flex items-center justify-center">
+    <p>If you see this page, the redirect failed.</p>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- inject a meta-refresh redirect after building
- simplify index page by removing async fetch logic

## Testing
- `npm test` *(fails: jest not found)*