### PR TITLE
Simplify date watchers

### DIFF
--- a/src/components/DateScroller.vue
+++ b/src/components/DateScroller.vue
@@ -48,6 +48,7 @@
 
 <script>
 import { computed } from 'vue';
+import { useRouter } from 'vue-router';
 
 export default {
   name: 'DateScroller',
@@ -67,6 +68,8 @@ export default {
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
+    const router = useRouter();
+
     // Computed properties
     const currentIndex = computed(() => {
       return props.dates.indexOf(props.modelValue);
@@ -104,6 +107,7 @@ export default {
       if (hasPrevious.value) {
         const newDate = props.dates[currentIndex.value - 1];
         emit('update:modelValue', newDate);
+        router.push({ path: `/${newDate}` });
       }
     };
 
@@ -111,6 +115,7 @@ export default {
       if (hasNext.value) {
         const newDate = props.dates[currentIndex.value + 1];
         emit('update:modelValue', newDate);
+        router.push({ path: `/${newDate}` });
       }
     };
 

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -64,7 +64,7 @@ onMounted(async () => {
 watch(
   () => route.params.date,
   newDate => {
-    if (newDate && newDate !== date.value) {
+    if (newDate) {
       console.log('Route date changed:', newDate);
       date.value = newDate;
       load(newDate);
@@ -72,14 +72,6 @@ watch(
   }
 );
 
-// Watch for date changes to reload data
-watch(date, newDate => {
-  console.log('Date changed:', newDate);
-  if (newDate) {
-    load(newDate);
-    router.push({ path: `/${newDate}` });
-  }
-});
 
 // Watch for dark mode changes to update body class
 watch(isDarkMode, val => {


### PR DESCRIPTION
## Summary
- keep only one watcher in `[date]` page
- push navigation from `DateScroller` component

## Testing
- `npm run test` *(fails: jest not found)*