### PR TITLE
Use dynamic import for posthog analytics

### DIFF
--- a/src/services/analytics/index.js
+++ b/src/services/analytics/index.js
@@ -1,4 +1,5 @@
-import posthog from 'posthog-js';
+// Dynamically imported PostHog instance
+let posthog;
 
 export const EVENT_CLICK_SITE_MARKER = 'click_site_marker';
 export const EVENT_CLICK_DATA_INFO_BUTTON = 'click_data_info_button';
@@ -8,11 +9,14 @@ export const EVENT_OPEN_POPUP = 'open_popup';
 
 let isInitialized = false;
 
-export function initAnalytics() {
+export async function initAnalytics() {
   const key = import.meta.env.VITE_POSTHOG_KEY;
   if (!key || isInitialized) {
     return;
   }
+
+  const mod = await import('posthog-js');
+  posthog = mod.default || mod;
 
   posthog.init(key, {
     api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://app.posthog.com',


### PR DESCRIPTION
## Summary
- lazy load `posthog-js` inside `initAnalytics`
- keep tracking no-op until analytics is initialized

## Testing
- `npm test` *(fails: jest not found)*