### PR TITLE
Wrap debug logs with production check

### DIFF
--- a/src/components/MapViewer.vue
+++ b/src/components/MapViewer.vue
@@ -234,7 +234,9 @@ export default {
       }
 
       // Log total number of features
-      console.log(`Total features on map: ${data.features.length}`);
+      if (import.meta.env.MODE !== 'production') {
+        console.log(`Total features on map: ${data.features.length}`);
+      }
 
       for (const feature of data.features) {
         try {

--- a/src/composables/useStaticData.js
+++ b/src/composables/useStaticData.js
@@ -9,7 +9,9 @@ export function useStaticData(dateRef) {
   const error = ref(null);
 
   async function load(currentDate = unref(dateRef)) {
-    console.log(`Loading data for date: ${currentDate}`);
+    if (import.meta.env.MODE !== 'production') {
+      console.log(`Loading data for date: ${currentDate}`);
+    }
 
     if (!currentDate) {
       console.error('No date provided');
@@ -28,7 +30,9 @@ export function useStaticData(dateRef) {
       const geojsonUrl = `${base}/data/${currentDate}/enriched.geojson`;
       const metadataUrl = `${base}/data/${currentDate}/metadata.json`;
 
-      console.log(`Fetching from: ${geojsonUrl} and ${metadataUrl}`);
+      if (import.meta.env.MODE !== 'production') {
+        console.log(`Fetching from: ${geojsonUrl} and ${metadataUrl}`);
+      }
 
       const [geojsonRes, metadataRes] = await Promise.all([fetch(geojsonUrl), fetch(metadataUrl)]);
 
@@ -43,8 +47,10 @@ export function useStaticData(dateRef) {
       const geojsonData = await geojsonRes.json();
       const metadataData = await metadataRes.json();
 
-      console.log('GeoJSON loaded with features:', geojsonData.features?.length);
-      console.log('Metadata loaded:', metadataData);
+      if (import.meta.env.MODE !== 'production') {
+        console.log('GeoJSON loaded with features:', geojsonData.features?.length);
+        console.log('Metadata loaded:', metadataData);
+      }
 
       data.value = geojsonData;
       metadata.value = metadataData;

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -57,7 +57,9 @@ onMounted(async () => {
 
   // Load data for the current date
   await load();
-  console.log('Data loaded:', data.value);
+  if (import.meta.env.MODE !== 'production') {
+    console.log('Data loaded:', data.value);
+  }
 });
 
 // Watch for route parameter changes
@@ -65,7 +67,9 @@ watch(
   () => route.params.date,
   newDate => {
     if (newDate && newDate !== date.value) {
-      console.log('Route date changed:', newDate);
+      if (import.meta.env.MODE !== 'production') {
+        console.log('Route date changed:', newDate);
+      }
       date.value = newDate;
       load(newDate);
     }
@@ -74,7 +78,9 @@ watch(
 
 // Watch for date changes to reload data
 watch(date, newDate => {
-  console.log('Date changed:', newDate);
+  if (import.meta.env.MODE !== 'production') {
+    console.log('Date changed:', newDate);
+  }
   if (newDate) {
     load(newDate);
     router.push({ path: `/${newDate}` });

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -8,7 +8,9 @@ const error = ref(null);
 
 onMounted(async () => {
   try {
-    console.log('Fetching latest date...');
+    if (import.meta.env.MODE !== 'production') {
+      console.log('Fetching latest date...');
+    }
     // Get the base URL for GitHub Pages
     const base = import.meta.env.MODE === 'production' ? '/nyc-water-app' : '';
     const response = await fetch(`${base}/data/latest.txt`);
@@ -19,7 +21,9 @@ onMounted(async () => {
 
     const latest = await response.text();
     const trimmedDate = latest.trim();
-    console.log('Latest date:', trimmedDate);
+    if (import.meta.env.MODE !== 'production') {
+      console.log('Latest date:', trimmedDate);
+    }
 
     if (trimmedDate) {
       router.push(`/${trimmedDate}`);


### PR DESCRIPTION
## Summary
- wrap `console.log` calls with a check to ensure they don't run in production

## Testing
- `npm test` *(fails: jest not found)*