### PR TITLE
Use router redirect for latest data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,6 @@ dist-ssr
 *.sw?
 .env
 .env.local
+# Build-time generated files
+src/generated/
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ The application uses a static data approach for improved performance and reliabi
      ascending order
 
 3. **Runtime Data Flow**:
-   - The index page reads `latest.txt` and redirects to the newest date
+   - The latest dataset date is compiled into the app during the build
+   - On load, the Vue router redirects to that newest date
    - Each date page fetches the corresponding `enriched.geojson` and `metadata.json`
    - All data is served as static files for fast loading
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && node scripts/inject-latest.js",
+    "build": "node scripts/gen-latest.js && vite build",
     "preview": "vite preview",
     "test": "jest",
     "enrich": "node scripts/enrich-data.js",

--- a/scripts/gen-latest.js
+++ b/scripts/gen-latest.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const PUBLIC_DIR = path.join(ROOT, 'public');
+const latestPath = path.join(PUBLIC_DIR, 'data', 'latest.txt');
+
+if (!fs.existsSync(latestPath)) {
+  console.error('latest.txt not found at', latestPath);
+  process.exit(1);
+}
+
+const latest = fs.readFileSync(latestPath, 'utf-8').trim();
+const outDir = path.join(ROOT, 'src', 'generated');
+fs.mkdirSync(outDir, { recursive: true });
+const outFile = path.join(outDir, 'latest-date.js');
+fs.writeFileSync(outFile, `export default '${latest}';\n`);

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,5 +1,13 @@
 <script setup>
-// Redirect handled in index.html during production build
+import { onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import latestDate from '../generated/latest-date.js';
+
+const router = useRouter();
+
+onMounted(() => {
+  router.replace(`/${latestDate}`);
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- generate latest dataset module during build
- redirect to newest dataset using Vue router
- ignore generated files
- update README runtime flow description

## Testing
- `npm run test` *(fails: jest not found)*