### PR TITLE
Add Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ npm run enrich
 npm run preview
 ```
 
+## Testing
+
+Run the Jest unit tests with:
+
+```bash
+npm test
+```
+
 ## Data Architecture
 
 The application uses a static data approach for improved performance and reliability:

--- a/tests/DataInfoPopup.test.js
+++ b/tests/DataInfoPopup.test.js
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils';
+import DataInfoPopup from '../src/components/DataInfoPopup.vue';
+
+jest.mock('../src/services/analytics', () => ({
+  track: jest.fn(),
+  EVENT_CLICK_DATA_INFO_BUTTON: 'click_data_info_button',
+  EVENT_CLICK_OUTBOUND_LINK: 'click_outbound_link',
+  EVENT_OPEN_POPUP: 'open_popup',
+}));
+
+const analytics = require('../src/services/analytics');
+
+describe('DataInfoPopup', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('toggles popup open state', async () => {
+    const wrapper = mount(DataInfoPopup, {
+      props: { isDarkMode: false, showNotification: false },
+    });
+
+    expect(wrapper.vm.isOpen.value).toBe(false);
+    wrapper.vm.togglePopup();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.isOpen.value).toBe(true);
+    expect(analytics.track).toHaveBeenCalledWith('open_popup', { component: 'DataInfoPopup' });
+    expect(analytics.track).toHaveBeenCalledWith('click_data_info_button');
+  });
+
+  test('tracks outbound links', () => {
+    const wrapper = mount(DataInfoPopup, {
+      props: { isDarkMode: false },
+    });
+    wrapper.vm.trackOutbound('https://example.com');
+    expect(analytics.track).toHaveBeenCalledWith('click_outbound_link', { url: 'https://example.com' });
+  });
+});

--- a/tests/MapViewer.test.js
+++ b/tests/MapViewer.test.js
@@ -1,0 +1,85 @@
+import { mount } from '@vue/test-utils';
+import MapViewer from '../src/components/MapViewer.vue';
+import { featurePopupOpen } from '../src/stores/featurePopupState';
+
+jest.mock('leaflet', () => {
+  const mapInstance = {
+    setView: jest.fn().mockReturnThis(),
+    removeControl: jest.fn(),
+    removeLayer: jest.fn(),
+    addLayer: jest.fn(),
+    getCenter: jest.fn(() => ({ lat: 0, lng: 0 })),
+    getZoom: jest.fn(() => 12),
+    fitBounds: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  return {
+    map: jest.fn(() => mapInstance),
+    tileLayer: jest.fn(() => ({ addTo: jest.fn() })),
+    divIcon: jest.fn(() => ({ options: {} })),
+    marker: jest.fn(() => {
+      let popupContent = '';
+      const marker = {
+        options: {},
+        bindPopup: jest.fn((content, options) => {
+          popupContent = content;
+          marker.popupOptions = options;
+          return marker;
+        }),
+        getPopup: jest.fn(() => ({ getContent: () => popupContent })),
+        closePopup: jest.fn(() => marker),
+        unbindPopup: jest.fn(() => marker),
+        addTo: jest.fn(() => marker),
+        on: jest.fn(),
+        remove: jest.fn(),
+      };
+      return marker;
+    }),
+    featureGroup: jest.fn(markers => ({ getBounds: jest.fn(() => ({})) })),
+  };
+});
+
+const sampleData = {
+  features: [
+    {
+      geometry: { type: 'Point', coordinates: [-74, 40] },
+      properties: { siteName: 'Site A', mpn: 10 },
+    },
+    {
+      geometry: { type: 'Point', coordinates: [-73, 41] },
+      properties: { siteName: 'Site B', mpn: 200 },
+    },
+  ],
+};
+
+describe('MapViewer', () => {
+  beforeEach(() => {
+    featurePopupOpen.value = false;
+  });
+
+  test('creates markers for GeoJSON features', async () => {
+    const wrapper = mount(MapViewer, {
+      props: { selectedDate: '2024-01-01', isDarkMode: false, geojson: sampleData },
+    });
+
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.markers.length).toBe(2);
+  });
+
+  test('updates popup styles when called', async () => {
+    const wrapper = mount(MapViewer, {
+      props: { selectedDate: '2024-01-01', isDarkMode: false, geojson: sampleData },
+    });
+
+    await wrapper.vm.$nextTick();
+    wrapper.setProps({ isDarkMode: true });
+    wrapper.vm.updatePopupStyles();
+
+    for (const marker of wrapper.vm.markers) {
+      expect(marker.bindPopup).toHaveBeenCalledWith(expect.any(String), {
+        className: 'dark-mode-popup',
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `MapViewer` marker handling
- add tests for `DataInfoPopup`
- document running `npm test`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683af67d12ac832e96cc44110252f17c