### PR TITLE
Add branch cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Data processing is handled by a single script:
   It also updates `latest.txt` and `dates.json` so the app automatically
   recognizes new datasets.
 
+Additional utilities:
+
+- `scripts/cleanup-branches.js` - Interactive utility to delete merged remote branches safely.
+
 ## Deployment
 
 The application is configured for deployment to GitHub Pages:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preview": "vite preview",
     "test": "jest",
     "enrich": "node scripts/enrich-data.js",
+    "cleanup": "node scripts/cleanup-branches.js",
     "predeploy": "npm run build && node scripts/copy-404.js",
     "deploy": "gh-pages -d dist"
   },

--- a/scripts/cleanup-branches.js
+++ b/scripts/cleanup-branches.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const readline = require('readline');
+
+function run(cmd) {
+  return execSync(cmd, { encoding: 'utf8' }).trim();
+}
+
+function listMergedBranches() {
+  const raw = run('git branch -r --merged origin/main');
+  return raw
+    .split('\n')
+    .map(b => b.trim())
+    .filter(b => b && !b.includes('->'))
+    .map(b => b.replace(/^origin\//, ''))
+    .filter(b => b !== 'main' && b !== 'dev' && !b.startsWith('feat/') && !b.startsWith('exp/'));
+}
+
+function confirm(rl, question) {
+  return new Promise(resolve => {
+    rl.question(question, answer => {
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+async function main() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const merged = listMergedBranches();
+
+  if (merged.length === 0) {
+    console.log('No merged branches found.');
+    rl.close();
+    return;
+  }
+
+  console.log('Merged branches eligible for deletion:\n');
+  merged.forEach(b => console.log('  ' + b));
+  console.log('');
+
+  const deleted = [];
+  for (const branch of merged) {
+    if (await confirm(rl, `Delete remote branch ${branch}? (y/N) `)) {
+      try {
+        run(`git push origin --delete ${branch}`);
+        deleted.push(branch);
+        console.log(`Deleted remote ${branch}`);
+      } catch (e) {
+        console.error(`Failed to delete remote ${branch}:`, e.message);
+      }
+    } else {
+      console.log(`Skipped ${branch}`);
+    }
+
+    if (await confirm(rl, `Delete local branch ${branch}? (y/N) `)) {
+      try {
+        run(`git branch -D ${branch}`);
+        console.log(`Deleted local ${branch}`);
+      } catch (e) {
+        console.error(`Failed to delete local ${branch}:`, e.message);
+      }
+    }
+    console.log('');
+  }
+
+  rl.close();
+
+  if (deleted.length) {
+    console.log('Removed remote branches:');
+    deleted.forEach(b => console.log('  ' + b));
+  } else {
+    console.log('No remote branches were deleted.');
+  }
+
+  console.log('\nCurrent remote branches:');
+  const final = run('git branch -r');
+  console.log(final);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `scripts/cleanup-branches.js` for interactively deleting merged branches
- document the cleanup script
- expose a `npm run cleanup` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448aeb4598832e96b7b2ecc316ae3b