### PR TITLE
Add rainfall trends view

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="p-4">
+    <canvas ref="chartCanvas"></canvas>
+  </div>
+</template>
+
+<script>
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
+
+export default {
+  name: 'RainfallSampleTrend',
+  props: {
+    history: {
+      type: Array,
+      required: true,
+    },
+  },
+  setup(props) {
+    const chartCanvas = ref(null);
+    let chartInstance = null;
+
+    const isThursday = dateStr => {
+      const d = new Date(dateStr + 'T00:00:00Z');
+      return d.getUTCDay() === 4; // Thursday
+    };
+
+    const loadChartJs = async () => {
+      if (!window.Chart) {
+        await import('https://cdn.jsdelivr.net/npm/chart.js');
+      }
+      return window.Chart;
+    };
+
+    const buildDatasets = () => {
+      const rainfall = [];
+      const good = [];
+      const caution = [];
+      const unsafe = [];
+
+      for (const entry of props.history) {
+        rainfall.push(entry.rainfall);
+        if (isThursday(entry.date)) {
+          const total =
+            entry.sampleSummary.good +
+            entry.sampleSummary.caution +
+            entry.sampleSummary.unsafe;
+          good.push((entry.sampleSummary.good / total) * 100);
+          caution.push((entry.sampleSummary.caution / total) * 100);
+          unsafe.push((entry.sampleSummary.unsafe / total) * 100);
+        } else {
+          good.push(null);
+          caution.push(null);
+          unsafe.push(null);
+        }
+      }
+
+      return { rainfall, good, caution, unsafe };
+    };
+
+    const createChart = async () => {
+      const Chart = await loadChartJs();
+      const ctx = chartCanvas.value.getContext('2d');
+      const labels = props.history.map(h => h.date);
+      const { rainfall, good, caution, unsafe } = buildDatasets();
+
+      chartInstance = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              type: 'line',
+              label: 'Rainfall (in)',
+              data: rainfall,
+              borderColor: '#3b82f6',
+              backgroundColor: '#3b82f6',
+              yAxisID: 'yRain',
+              tension: 0.3,
+            },
+            {
+              type: 'bar',
+              label: 'Good',
+              data: good,
+              backgroundColor: '#16a34a',
+              stack: 'samples',
+              yAxisID: 'ySample',
+            },
+            {
+              type: 'bar',
+              label: 'Caution',
+              data: caution,
+              backgroundColor: '#eab308',
+              stack: 'samples',
+              yAxisID: 'ySample',
+            },
+            {
+              type: 'bar',
+              label: 'Unsafe',
+              data: unsafe,
+              backgroundColor: '#dc2626',
+              stack: 'samples',
+              yAxisID: 'ySample',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          interaction: { mode: 'index' },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Rainfall + Weekly Water Quality Breakdown',
+            },
+            tooltip: {
+              callbacks: {
+                label: context => {
+                  if (context.dataset.type === 'line') {
+                    return `Rainfall: ${context.parsed.y} in`;
+                  }
+                  return `${context.dataset.label}: ${Math.round(context.parsed.y)}%`;
+                },
+                afterBody: ctx => {
+                  const index = ctx[0].dataIndex;
+                  const item = props.history[index];
+                  if (!item || !isThursday(item.date)) return [];
+                  const total =
+                    item.sampleSummary.good +
+                    item.sampleSummary.caution +
+                    item.sampleSummary.unsafe;
+                  return [
+                    `Total samples: ${total}`,
+                    `Good: ${item.sampleSummary.good}`,
+                    `Caution: ${item.sampleSummary.caution}`,
+                    `Unsafe: ${item.sampleSummary.unsafe}`,
+                  ];
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              ticks: {
+                callback: (val, idx) => {
+                  const label = labels[idx];
+                  if (isThursday(label)) {
+                    const [y, m, d] = label.split('-');
+                    return `${m}/${d}`;
+                  }
+                  return '';
+                },
+              },
+            },
+            yRain: {
+              position: 'left',
+              title: {
+                display: true,
+                text: 'Rainfall (in)',
+              },
+            },
+            ySample: {
+              position: 'right',
+              min: 0,
+              max: 100,
+              title: {
+                display: true,
+                text: 'Sample Results (%)',
+              },
+              ticks: {
+                callback: value => `${value}%`,
+              },
+            },
+          },
+        },
+      });
+    };
+
+    onMounted(createChart);
+
+    watch(
+      () => props.history,
+      () => {
+        if (chartInstance) {
+          chartInstance.destroy();
+        }
+        createChart();
+      },
+      { deep: true }
+    );
+
+    onBeforeUnmount(() => {
+      if (chartInstance) {
+        chartInstance.destroy();
+      }
+    });
+
+    return { chartCanvas };
+  },
+};
+</script>
+
+<style scoped>
+canvas {
+  max-height: 300px;
+}
+</style>
+

--- a/src/components/TrendsButton.vue
+++ b/src/components/TrendsButton.vue
@@ -1,0 +1,47 @@
+<template>
+  <button
+    :class="[
+      'fixed bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] left-1/2 transform -translate-x-1/2 ml-[6rem] z-[300] rounded-full h-10 px-4 flex items-center justify-center shadow-lg transition-colors duration-300',
+      isDarkMode ? 'bg-gray-800 text-gray-200 hover:bg-gray-700' : 'bg-white text-gray-800 hover:bg-gray-100'
+    ]"
+    :style="{ pointerEvents: 'auto', touchAction: 'manipulation' }"
+    title="Trends"
+    @click="goToTrends"
+    @touchstart.stop.prevent="goToTrends"
+  >
+    <span class="font-semibold text-sm pointer-events-none">Trends</span>
+  </button>
+</template>
+
+<script>
+import { useRouter } from 'vue-router';
+
+export default {
+  name: 'TrendsButton',
+  props: {
+    isDarkMode: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup() {
+    const router = useRouter();
+
+    /**
+     * Navigate to the trends page.
+     */
+    const goToTrends = () => {
+      router.push('/trends');
+    };
+
+    return { goToTrends };
+  },
+};
+</script>
+
+<style scoped>
+button {
+  min-width: 4rem;
+}
+</style>
+

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { initAnalytics, track } from './services/analytics';
 // Pages
 import IndexPage from './pages/index.vue';
 import DatePage from './pages/[date].vue';
+import TrendsPage from './pages/trends.vue';
 
 // Create router with correct base path for GitHub Pages
 const base = import.meta.env.MODE === 'production' ? '/nyc-water-app/' : '/';
@@ -15,6 +16,7 @@ const router = createRouter({
   routes: [
     { path: '/', component: IndexPage },
     { path: '/:date', component: DatePage },
+    { path: '/trends', component: TrendsPage },
   ],
 });
 

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -8,6 +8,7 @@ import DateScroller from '../components/DateScroller.vue';
 import InfoPopup from '../components/InfoPopup.vue';
 import DataInfoPopup from '../components/DataInfoPopup.vue';
 import DonatePopup from '../components/DonatePopup.vue';
+import TrendsButton from '../components/TrendsButton.vue';
 import { useStaticData } from '../composables/useStaticData';
 
 const route = useRoute();
@@ -119,6 +120,7 @@ const toggleDarkMode = () => {
         :showNotification="showDataInfoNotification"
       />
       <DonatePopup :isDarkMode="isDarkMode" />
+      <TrendsButton :isDarkMode="isDarkMode" />
     </div>
 
     <div v-else class="text-center h-screen flex items-center justify-center flex-col">

--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -1,0 +1,42 @@
+<script setup>
+import RainfallSampleTrend from '../components/RainfallSampleTrend.vue';
+
+const mockData = [
+  { date: '2024-06-06', rainfall: 0.4, sampleSummary: { good: 12, caution: 4, unsafe: 6 } },
+  { date: '2024-06-07', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-08', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-09', rainfall: 0.2, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-10', rainfall: 0.3, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-11', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-12', rainfall: 0.5, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-13', rainfall: 0.6, sampleSummary: { good: 10, caution: 5, unsafe: 7 } },
+  { date: '2024-06-14', rainfall: 0.2, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-15', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-16', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-17', rainfall: 0.3, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-18', rainfall: 0.4, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-19', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-20', rainfall: 0.7, sampleSummary: { good: 8, caution: 8, unsafe: 6 } },
+  { date: '2024-06-21', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-22', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-23', rainfall: 0.4, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-24', rainfall: 0.6, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-25', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-26', rainfall: 0.3, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-27', rainfall: 0.5, sampleSummary: { good: 11, caution: 6, unsafe: 7 } },
+  { date: '2024-06-28', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-29', rainfall: 0.2, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-06-30', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-07-01', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-07-02', rainfall: 0.4, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-07-03', rainfall: 0.5, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
+  { date: '2024-07-04', rainfall: 0.8, sampleSummary: { good: 9, caution: 7, unsafe: 8 } },
+];
+</script>
+
+<template>
+  <div class="min-h-screen flex flex-col">
+    <RainfallSampleTrend :history="mockData" />
+  </div>
+</template>
+


### PR DESCRIPTION
## Summary
- add `RainfallSampleTrend` chart component using Chart.js CDN
- create `TrendsButton` navigation button
- insert the new button on the daily map page
- add a new `/trends` route and page with mock data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a521fc28832ea6baf1b267c924f3