### PR TITLE
Add rainfall trends visualization

### DIFF
--- a/src/components/TrendsButton.vue
+++ b/src/components/TrendsButton.vue
@@ -1,15 +1,15 @@
 <template>
   <button
     :class="[
-      'fixed bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] left-1/2 transform -translate-x-1/2 ml-[6rem] z-[300] rounded-full h-10 px-4 flex items-center justify-center shadow-lg transition-colors duration-300',
+      'fixed bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] left-1/2 transform -translate-x-1/2 ml-[6rem] z-[300] rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-colors duration-300',
       isDarkMode ? 'bg-gray-800 text-gray-200 hover:bg-gray-700' : 'bg-white text-gray-800 hover:bg-gray-100'
     ]"
     :style="{ pointerEvents: 'auto', touchAction: 'manipulation' }"
-    title="Trends"
+    aria-label="Trends"
     @click="goToTrends"
     @touchstart.stop.prevent="goToTrends"
   >
-    <span class="font-semibold text-sm pointer-events-none">Trends</span>
+    <span class="text-lg pointer-events-none">📊</span>
   </button>
 </template>
 

--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -1,42 +1,60 @@
 <script setup>
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 import RainfallSampleTrend from '../components/RainfallSampleTrend.vue';
 
-const mockData = [
-  { date: '2024-06-06', rainfall: 0.4, sampleSummary: { good: 12, caution: 4, unsafe: 6 } },
-  { date: '2024-06-07', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-08', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-09', rainfall: 0.2, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-10', rainfall: 0.3, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-11', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-12', rainfall: 0.5, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-13', rainfall: 0.6, sampleSummary: { good: 10, caution: 5, unsafe: 7 } },
-  { date: '2024-06-14', rainfall: 0.2, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-15', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-16', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-17', rainfall: 0.3, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-18', rainfall: 0.4, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-19', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-20', rainfall: 0.7, sampleSummary: { good: 8, caution: 8, unsafe: 6 } },
-  { date: '2024-06-21', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-22', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-23', rainfall: 0.4, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-24', rainfall: 0.6, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-25', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-26', rainfall: 0.3, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-27', rainfall: 0.5, sampleSummary: { good: 11, caution: 6, unsafe: 7 } },
-  { date: '2024-06-28', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-29', rainfall: 0.2, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-06-30', rainfall: 0.1, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-07-01', rainfall: 0.0, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-07-02', rainfall: 0.4, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-07-03', rainfall: 0.5, sampleSummary: { good: 0, caution: 0, unsafe: 0 } },
-  { date: '2024-07-04', rainfall: 0.8, sampleSummary: { good: 9, caution: 7, unsafe: 8 } },
-];
+const history = ref([]);
+const loading = ref(true);
+const router = useRouter();
+
+onMounted(async () => {
+  try {
+    const base = import.meta.env.MODE === 'production' ? '/nyc-water-app' : '';
+    const res = await fetch(`${base}/data/dates.json`);
+    const dates = (await res.json()) || [];
+    const weekly = [];
+    for (const date of dates) {
+      const geoRes = await fetch(`${base}/data/${date}/enriched.geojson`);
+      if (!geoRes.ok) continue;
+      const geo = await geoRes.json();
+      const summary = { good: 0, caution: 0, unsafe: 0 };
+      for (const f of geo.features) {
+        const mpn = Number(f.properties.mpn);
+        if (mpn < 35) summary.good++;
+        else if (mpn <= 104) summary.caution++;
+        else summary.unsafe++;
+      }
+      const rainfallByDay = geo.features[0]?.properties.rainByDay || [];
+      weekly.push({ date, rainfallByDay, sampleSummary: summary });
+    }
+    history.value = weekly.sort((a, b) => a.date.localeCompare(b.date));
+  } catch (err) {
+    console.warn('Error loading trend data:', err);
+  } finally {
+    loading.value = false;
+  }
+});
+
+const goHome = () => router.push('/');
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col">
-    <RainfallSampleTrend :history="mockData" />
+  <div class="min-h-screen flex flex-col p-4">
+    <p class="mb-4 text-sm text-gray-800 dark:text-gray-200">
+      Each dot in the line shows daily rainfall totals for the past several weeks. Water quality
+      samples are collected on Thursdays, and each stacked bar shows how many samples fell into good,
+      caution, or unsafe zones that day. Since NYC’s sewers overflow during storms, rainfall right
+      before Thursday is the biggest factor in poor water quality.
+    </p>
+
+    <div v-if="loading" class="text-center py-10">Loading…</div>
+    <RainfallSampleTrend v-else :history="history" />
+
+    <button
+      class="mt-6 self-center px-4 py-2 rounded font-semibold bg-gray-800 text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-gray-300"
+      @click="goHome"
+    >
+      ← Back to Map
+    </button>
   </div>
 </template>
-


### PR DESCRIPTION
## Summary
- load real GeoJSON history in `/trends`
- aggregate sample results and rainfall by date
- show explanatory text and back nav
- update chart logic to plot rainfall by day with stacked bars
- add 📊 trends button with icon

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a9b00184832e9ec0bb588af629f5