### PR TITLE
Improve trends layout and theme

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -1,15 +1,7 @@
 <template>
-  <div class="p-4">
-    <div class="flex justify-center text-sm mb-2 space-x-4">
-      <div class="flex items-center" v-for="item in legend" :key="item.label">
-        <span :class="['inline-block w-3 h-3 rounded-sm mr-1', item.color]"></span>
-        <span class="text-gray-700 dark:text-gray-300">{{ item.label }}</span>
-      </div>
-    </div>
-    <div ref="scrollContainer" class="overflow-x-auto">
-      <div class="min-w-[600px]" :style="{ width: canvasWidth + 'px' }">
-        <canvas ref="chartCanvas"></canvas>
-      </div>
+  <div ref="scrollContainer" class="overflow-x-auto p-4">
+    <div class="min-w-[600px]" :style="{ width: canvasWidth + 'px' }">
+      <canvas ref="chartCanvas"></canvas>
     </div>
   </div>
 </template>
@@ -34,12 +26,6 @@ export default {
     const scrollContainer = ref(null);
     let chartInstance = null;
 
-    const legend = [
-      { label: 'Rainfall (in)', color: 'bg-blue-500' },
-      { label: 'Good (<35)', color: 'bg-green-600' },
-      { label: 'Caution (35–104)', color: 'bg-yellow-400' },
-      { label: 'Unsafe (>104)', color: 'bg-red-600' },
-    ];
 
     const isThursday = dateStr => {
       const d = new Date(dateStr + 'T00:00:00Z');
@@ -264,7 +250,7 @@ export default {
       }
     });
 
-    return { chartCanvas, scrollContainer, canvasWidth, legend };
+    return { chartCanvas, scrollContainer, canvasWidth };
   },
 };
 </script>

--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -1,12 +1,10 @@
 <script setup>
 import { ref, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
 import RainfallSampleTrend from '../components/RainfallSampleTrend.vue';
 import { isDarkMode, toggleDarkMode } from '../stores/theme';
 
 const history = ref([]);
 const loading = ref(true);
-const router = useRouter();
 
 onMounted(async () => {
   try {
@@ -36,35 +34,48 @@ onMounted(async () => {
   }
 });
 
-const goHome = () => router.push('/');
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col max-w-screen-lg mx-auto px-4 py-4 text-gray-800 dark:text-gray-200">
-    <!-- Theme toggle -->
-    <button
-      @click="toggleDarkMode"
-      class="fixed top-4 right-4 z-50 w-10 h-10 rounded-full shadow-md flex items-center justify-center transition-colors duration-300"
-      :class="isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-800'"
-    >
-      {{ isDarkMode ? '☀️' : '🌙' }}
-    </button>
+  <div class="min-h-screen bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-200">
+    <div class="max-w-screen-lg mx-auto px-4 py-6 text-center">
+      <!-- Theme toggle -->
+      <button
+        @click="toggleDarkMode"
+        class="fixed top-4 right-4 z-50 w-10 h-10 rounded-full shadow-md flex items-center justify-center transition-colors duration-300"
+        :class="isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-800'"
+      >
+        {{ isDarkMode ? '☀️' : '🌙' }}
+      </button>
 
-    <div v-if="loading" class="text-center py-10">Loading…</div>
-    <RainfallSampleTrend v-else :history="history" :isDarkMode="isDarkMode" />
+      <h1 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">
+        Trends: Rainfall vs Water Quality
+      </h1>
 
-    <p class="text-sm mt-4 max-w-2xl text-gray-400 dark:text-gray-300">
-      Each dot in the line shows daily rainfall totals for the past several weeks. Water quality
-      samples are collected on Thursdays, and each stacked bar shows how many samples fell into good,
-      caution, or unsafe zones that day. Since NYC’s sewers overflow during storms, rainfall right
-      before Thursday is the biggest factor in poor water quality.
-    </p>
+      <div class="flex flex-wrap justify-center gap-4 mb-4 text-sm font-medium">
+        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-blue-500 rounded"></span> Rainfall (in)</div>
+        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-green-500 rounded"></span> Good (<35)</div>
+        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-yellow-400 rounded"></span> Caution (35–104)</div>
+        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-red-500 rounded"></span> Unsafe (>104)</div>
+      </div>
 
-    <button
-      class="mt-6 self-center px-4 py-2 rounded font-semibold bg-gray-800 text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-gray-300"
-      @click="goHome"
-    >
-      ← Back to Map
-    </button>
+      <div v-if="loading" class="text-center py-10">Loading…</div>
+      <div v-else class="overflow-x-auto">
+        <RainfallSampleTrend :history="history" :isDarkMode="isDarkMode" />
+      </div>
+
+      <p class="text-base text-gray-700 dark:text-gray-300 mt-6 max-w-prose mx-auto">
+        Each dot in the line shows daily rainfall totals for the past several weeks. Water quality
+        samples are collected on Thursdays, and each stacked bar shows how many samples fell into good,
+        caution, or unsafe zones that day. Since NYC’s sewers overflow during storms, rainfall right
+        before Thursday is the biggest factor in poor water quality.
+      </p>
+
+      <router-link to="/" class="inline-block mt-8">
+        <button class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-black dark:text-white rounded hover:bg-gray-300 dark:hover:bg-gray-600">
+          ← Back to Map
+        </button>
+      </router-link>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- tidy up `/trends` page structure
- add heading, legend, and styling
- improve responsiveness and dark mode
- remove legend from `RainfallSampleTrend`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b16e2420832e861a4ae5a6182faa