### PR TITLE
Fix theme toggle on trends chart

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -244,6 +244,16 @@ export default {
       { deep: true }
     );
 
+    watch(
+      () => props.isDarkMode,
+      () => {
+        if (chartInstance) {
+          chartInstance.destroy();
+        }
+        createChart();
+      }
+    );
+
     onBeforeUnmount(() => {
       if (chartInstance) {
         chartInstance.destroy();


### PR DESCRIPTION
## Summary
- update `RainfallSampleTrend.vue` so the chart updates when dark mode changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b2e5e9e8832e9b2e39b526ed40ff