### PR TITLE
Remove duplicate legend from trend graph

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -142,15 +142,16 @@ export default {
             },
           ],
         },
-        options: {
-          responsive: true,
-          interaction: { mode: 'index' },
-          plugins: {
-            title: {
-              display: true,
-              text: 'Rainfall + Weekly Water Quality Breakdown',
-              color: textColor,
-            },
+          options: {
+            responsive: true,
+            interaction: { mode: 'index' },
+            plugins: {
+              legend: { display: false },
+              title: {
+                display: true,
+                text: 'Rainfall + Weekly Water Quality Breakdown',
+                color: textColor,
+              },
             tooltip: {
               callbacks: {
                 label: context => {


### PR DESCRIPTION
## Summary
- disable Chart.js legend in `RainfallSampleTrend.vue` since the page already has its own legend

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b314355c832ea72945fa5c40c63a