### PR TITLE
Clarify trend page legend

### DIFF
--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -54,9 +54,9 @@ onMounted(async () => {
 
       <div class="flex flex-wrap justify-center gap-4 mb-4 text-sm font-medium">
         <div class="flex items-center gap-2"><span class="w-4 h-4 bg-blue-500 rounded"></span> Rainfall (in)</div>
-        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-green-500 rounded"></span> Good (<35)</div>
-        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-yellow-400 rounded"></span> Caution (35–104)</div>
-        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-red-500 rounded"></span> Unsafe (>104)</div>
+        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-green-500 rounded"></span> % of samples testing good (<35)</div>
+        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-yellow-400 rounded"></span> % of samples testing caution (35–104)</div>
+        <div class="flex items-center gap-2"><span class="w-4 h-4 bg-red-500 rounded"></span> % of samples testing unsafe (>104)</div>
       </div>
 
       <div v-if="loading" class="text-center py-10">Loading…</div>


### PR DESCRIPTION
## Summary
- clarify that each color bar shows the percentage of samples in each quality range

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b5e485ac832ebd22acd419088903