### PR TITLE
Fix stacked bar rendering for sample trend chart

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -253,6 +253,7 @@ export default {
           },
           scales: {
             x: {
+              stacked: true,
               ticks: {
                 display: false,
                 callback: (val, idx) => {
@@ -276,6 +277,7 @@ export default {
             },
             ySample: {
               position: 'right',
+              stacked: true,
               min: 0,
               max: 100,
               title: {


### PR DESCRIPTION
## Summary
- ensure the Chart.js scales are stacked for sample data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845be227994832e9483f2662def62b1