### PR TITLE
Fix overlay axes tick index

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -133,8 +133,8 @@ export default {
         ctx.stroke();
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
-        x.ticks.forEach(t => {
-          const pos = x.getPixelForTick(t.index) - chartArea.left;
+        x.ticks.forEach((t, idx) => {
+          const pos = x.getPixelForTick(idx) - chartArea.left;
           ctx.beginPath();
           ctx.moveTo(pos, chartArea.bottom);
           ctx.lineTo(pos, chartArea.bottom + 4);


### PR DESCRIPTION
## Summary
- fix overlayAxes plugin tick calculation to use forEach index

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bff75d20832ea325fd6835cb0087