### PR TITLE
Fix rainfall slicing and update dataset

### DIFF
--- a/public/data/2025-06-05/enriched.geojson
+++ b/public/data/2025-06-05/enriched.geojson
@@ -16,8 +16,6 @@
         "timestamp": "2025-06-05T08:45:00.000Z",
         "sampleTime": "2025-06-05T08:45:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -26,8 +24,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -51,8 +49,6 @@
         "timestamp": "2025-06-05T08:35:00.000Z",
         "sampleTime": "2025-06-05T08:35:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -61,8 +57,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -86,8 +82,6 @@
         "timestamp": "2025-06-05T09:01:00.000Z",
         "sampleTime": "2025-06-05T09:01:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -96,8 +90,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -121,8 +115,6 @@
         "timestamp": "2025-06-05T09:03:00.000Z",
         "sampleTime": "2025-06-05T09:03:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -131,8 +123,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -156,8 +148,6 @@
         "timestamp": "2025-06-05T09:50:00.000Z",
         "sampleTime": "2025-06-05T09:50:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -166,8 +156,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -191,8 +181,6 @@
         "timestamp": "2025-06-05T08:14:00.000Z",
         "sampleTime": "2025-06-05T08:14:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -201,8 +189,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -226,8 +214,6 @@
         "timestamp": "2025-06-05T11:23:00.000Z",
         "sampleTime": "2025-06-05T11:23:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -236,8 +222,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.89 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -261,8 +247,6 @@
         "timestamp": "2025-06-05T11:37:00.000Z",
         "sampleTime": "2025-06-05T11:37:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -271,8 +255,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.19 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -296,8 +280,6 @@
         "timestamp": "2025-06-05T11:43:00.000Z",
         "sampleTime": "2025-06-05T11:43:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -306,8 +288,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.19 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -331,8 +313,6 @@
         "timestamp": "2025-06-05T12:17:00.000Z",
         "sampleTime": "2025-06-05T12:17:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -341,8 +321,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.19 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -366,8 +346,6 @@
         "timestamp": "2025-06-05T11:55:00.000Z",
         "sampleTime": "2025-06-05T11:55:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -376,8 +354,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.19 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -401,8 +379,6 @@
         "timestamp": "2025-06-05T09:46:00.000Z",
         "sampleTime": "2025-06-05T09:46:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -411,8 +387,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -436,8 +412,6 @@
         "timestamp": "2025-06-05T09:37:00.000Z",
         "sampleTime": "2025-06-05T09:37:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -446,8 +420,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -471,8 +445,6 @@
         "timestamp": "2025-06-05T09:44:00.000Z",
         "sampleTime": "2025-06-05T09:44:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -481,8 +453,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -506,8 +478,6 @@
         "timestamp": "2025-06-05T10:05:00.000Z",
         "sampleTime": "2025-06-05T10:05:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -516,8 +486,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -541,8 +511,6 @@
         "timestamp": "2025-06-05T09:54:00.000Z",
         "sampleTime": "2025-06-05T09:54:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -551,8 +519,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -576,8 +544,6 @@
         "timestamp": "2025-06-05T10:20:00.000Z",
         "sampleTime": "2025-06-05T10:20:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -586,8 +552,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -611,8 +577,6 @@
         "timestamp": "2025-06-05T11:26:00.000Z",
         "sampleTime": "2025-06-05T11:26:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -621,8 +585,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.89 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -646,8 +610,6 @@
         "timestamp": "2025-06-05T11:10:00.000Z",
         "sampleTime": "2025-06-05T11:10:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -656,8 +618,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.89 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -681,8 +643,6 @@
         "timestamp": "2025-06-05T07:24:00.000Z",
         "sampleTime": "2025-06-05T07:24:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -691,8 +651,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.62 ft",
         "tideState": "Mid Tide – ⬆️ Rising (The Battery)",
         "tide": "Mid Tide – ⬆️ Rising (The Battery)",
@@ -716,8 +676,6 @@
         "timestamp": "2025-06-05T06:55:00.000Z",
         "sampleTime": "2025-06-05T06:55:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -726,8 +684,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.62 ft",
         "tideState": "Mid Tide – ⬆️ Rising (The Battery)",
         "tide": "Mid Tide – ⬆️ Rising (The Battery)",
@@ -751,8 +709,6 @@
         "timestamp": "2025-06-05T09:14:00.000Z",
         "sampleTime": "2025-06-05T09:14:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -761,8 +717,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide – ⬇️ Falling (The Battery)",
         "tide": "High Tide – ⬇️ Falling (The Battery)",
@@ -786,8 +742,6 @@
         "timestamp": "2025-06-05T10:02:00.000Z",
         "sampleTime": "2025-06-05T10:02:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -796,8 +750,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -821,8 +775,6 @@
         "timestamp": "2025-06-05T08:02:00.000Z",
         "sampleTime": "2025-06-05T08:02:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -831,8 +783,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide (The Battery)",
         "tide": "High Tide (The Battery)",
@@ -856,8 +808,6 @@
         "timestamp": "2025-06-05T09:30:00.000Z",
         "sampleTime": "2025-06-05T09:30:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -866,8 +816,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide – ⬇️ Falling (The Battery)",
         "tide": "High Tide – ⬇️ Falling (The Battery)",
@@ -891,8 +841,6 @@
         "timestamp": "2025-06-05T06:51:00.000Z",
         "sampleTime": "2025-06-05T06:51:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -901,8 +849,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.62 ft",
         "tideState": "Mid Tide – ⬆️ Rising (The Battery)",
         "tide": "Mid Tide – ⬆️ Rising (The Battery)",
@@ -926,8 +874,6 @@
         "timestamp": "2025-06-05T06:50:00.000Z",
         "sampleTime": "2025-06-05T06:50:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -936,8 +882,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.62 ft",
         "tideState": "Mid Tide – ⬆️ Rising (The Battery)",
         "tide": "Mid Tide – ⬆️ Rising (The Battery)",
@@ -961,8 +907,6 @@
         "timestamp": "2025-06-05T10:00:00.000Z",
         "sampleTime": "2025-06-05T10:00:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -971,8 +915,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -996,8 +940,6 @@
         "timestamp": "2025-06-05T10:05:00.000Z",
         "sampleTime": "2025-06-05T10:05:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1006,8 +948,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1031,8 +973,6 @@
         "timestamp": "2025-06-05T08:33:00.000Z",
         "sampleTime": "2025-06-05T08:33:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1041,8 +981,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide – ⬇️ Falling (The Battery)",
         "tide": "High Tide – ⬇️ Falling (The Battery)",
@@ -1066,8 +1006,6 @@
         "timestamp": "2025-06-05T11:02:00.000Z",
         "sampleTime": "2025-06-05T11:02:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1076,8 +1014,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.89 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1101,8 +1039,6 @@
         "timestamp": "2025-06-05T10:47:00.000Z",
         "sampleTime": "2025-06-05T10:47:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1111,8 +1047,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.89 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1136,8 +1072,6 @@
         "timestamp": "2025-06-05T07:36:00.000Z",
         "sampleTime": "2025-06-05T07:36:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1146,8 +1080,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide (The Battery)",
         "tide": "High Tide (The Battery)",
@@ -1171,8 +1105,6 @@
         "timestamp": "2025-06-05T07:40:00.000Z",
         "sampleTime": "2025-06-05T07:40:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1181,8 +1113,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide (The Battery)",
         "tide": "High Tide (The Battery)",
@@ -1206,8 +1138,6 @@
         "timestamp": "2025-06-05T09:06:00.000Z",
         "sampleTime": "2025-06-05T09:06:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1216,8 +1146,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide – ⬇️ Falling (The Battery)",
         "tide": "High Tide – ⬇️ Falling (The Battery)",
@@ -1241,8 +1171,6 @@
         "timestamp": "2025-06-05T08:06:00.000Z",
         "sampleTime": "2025-06-05T08:06:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1251,8 +1179,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide (The Battery)",
         "tide": "High Tide (The Battery)",
@@ -1276,8 +1204,6 @@
         "timestamp": "2025-06-05T11:25:00.000Z",
         "sampleTime": "2025-06-05T11:25:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1286,8 +1212,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "2.89 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1311,8 +1237,6 @@
         "timestamp": "2025-06-05T08:30:00.000Z",
         "sampleTime": "2025-06-05T08:30:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1321,8 +1245,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide (The Battery)",
         "tide": "High Tide (The Battery)",
@@ -1346,8 +1270,6 @@
         "timestamp": "2025-06-05T09:10:00.000Z",
         "sampleTime": "2025-06-05T09:10:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1356,8 +1278,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide – ⬇️ Falling (The Battery)",
         "tide": "High Tide – ⬇️ Falling (The Battery)",
@@ -1381,8 +1303,6 @@
         "timestamp": "2025-06-05T08:58:00.000Z",
         "sampleTime": "2025-06-05T08:58:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1391,8 +1311,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide – ⬇️ Falling (The Battery)",
         "tide": "High Tide – ⬇️ Falling (The Battery)",
@@ -1416,8 +1336,6 @@
         "timestamp": "2025-06-05T09:33:00.000Z",
         "sampleTime": "2025-06-05T09:33:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1426,8 +1344,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1451,8 +1369,6 @@
         "timestamp": "2025-06-05T09:41:00.000Z",
         "sampleTime": "2025-06-05T09:41:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1461,8 +1377,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1486,8 +1402,6 @@
         "timestamp": "2025-06-05T07:25:00.000Z",
         "sampleTime": "2025-06-05T07:25:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1496,8 +1410,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.62 ft",
         "tideState": "Mid Tide – ⬆️ Rising (The Battery)",
         "tide": "Mid Tide – ⬆️ Rising (The Battery)",
@@ -1521,8 +1435,6 @@
         "timestamp": "2025-06-05T07:30:00.000Z",
         "sampleTime": "2025-06-05T07:30:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1531,8 +1443,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.62 ft",
         "tideState": "Mid Tide – ⬆️ Rising (The Battery)",
         "tide": "Mid Tide – ⬆️ Rising (The Battery)",
@@ -1556,8 +1468,6 @@
         "timestamp": "2025-06-05T07:35:00.000Z",
         "sampleTime": "2025-06-05T07:35:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1566,8 +1476,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "4.00 ft",
         "tideState": "High Tide (The Battery)",
         "tide": "High Tide (The Battery)",
@@ -1591,8 +1501,6 @@
         "timestamp": "2025-06-05T06:40:00.000Z",
         "sampleTime": "2025-06-05T06:40:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1601,8 +1509,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.62 ft",
         "tideState": "Mid Tide – ⬆️ Rising (The Battery)",
         "tide": "Mid Tide – ⬆️ Rising (The Battery)",
@@ -1626,8 +1534,6 @@
         "timestamp": "2025-06-05T09:30:00.000Z",
         "sampleTime": "2025-06-05T09:30:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1636,8 +1542,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -1661,8 +1567,6 @@
         "timestamp": "2025-06-05T08:59:00.000Z",
         "sampleTime": "2025-06-05T08:59:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1671,8 +1575,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -1696,8 +1600,6 @@
         "timestamp": "2025-06-05T09:27:00.000Z",
         "sampleTime": "2025-06-05T09:27:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1706,8 +1608,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -1731,8 +1633,6 @@
         "timestamp": "2025-06-05T09:48:00.000Z",
         "sampleTime": "2025-06-05T09:48:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1741,8 +1641,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1766,8 +1666,6 @@
         "timestamp": "2025-06-05T10:28:00.000Z",
         "sampleTime": "2025-06-05T10:28:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1776,8 +1674,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "3.58 ft",
         "tideState": "Mid Tide – ⬇️ Falling (The Battery)",
         "tide": "Mid Tide – ⬇️ Falling (The Battery)",
@@ -1801,8 +1699,6 @@
         "timestamp": "2025-06-05T10:50:00.000Z",
         "sampleTime": "2025-06-05T10:50:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1811,8 +1707,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",
@@ -1836,8 +1732,6 @@
         "timestamp": "2025-06-05T11:00:00.000Z",
         "sampleTime": "2025-06-05T11:00:00.000Z",
         "rainByDay": [
-          0.01,
-          0.46,
           0,
           0,
           0,
@@ -1846,8 +1740,8 @@
           0,
           0
         ],
-        "totalRain": 0.47000000000000003,
-        "rainfall_mm_7day": 11.938,
+        "totalRain": 0,
+        "rainfall_mm_7day": 0,
         "tideHeight": "No tide station nearby",
         "tideState": "Tide info unavailable",
         "tide": "Tide info unavailable",

--- a/public/data/2025-06-05/metadata.json
+++ b/public/data/2025-06-05/metadata.json
@@ -1,6 +1,6 @@
 {
   "date": "2025-06-05",
-  "totalRain": 0.47000000000000003,
+  "totalRain": 0,
   "sampleCount": 53,
   "description": "Water quality samples from 2025-06-05"
 }

--- a/scripts/enrich-data.js
+++ b/scripts/enrich-data.js
@@ -266,10 +266,10 @@ async function processDateFiles(date, sampleFile, rainFile, historyCounts) {
         key => key.toLowerCase().includes('precip') || key.toLowerCase().includes('rain')
       ) || Object.keys(rainfall[0])[0]; // Fallback to first column
 
-    const rainByDay = rainfall.map(row => {
-      const value = parseFloat(row[rainColumn]);
-      return isNaN(value) ? 0 : value;
-    });
+    const rainByDay = rainfall
+      .map(row => parseFloat(row[rainColumn]))
+      .filter(v => !Number.isNaN(v))
+      .slice(-7);
 
     const totalRain = rainByDay.reduce((sum, val) => sum + val, 0);
     // Convert the 7-day rainfall total from inches to millimeters for easier


### PR DESCRIPTION
## Summary
- trim rainfall data to last seven numbers when enriching samples
- regenerate dataset for 2025‑06‑05 so each feature stores only 7 days of rain

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bfdad2a4832e96ead7c5a68e60c7