### PR TITLE
Remove width class from TrendsButton

### DIFF
--- a/src/components/TrendsButton.vue
+++ b/src/components/TrendsButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     :class="[
-      'rounded-full w-10 h-10 flex items-center justify-center shadow-lg transition-colors duration-300 pointer-events-auto touch-action-manipulation',
+      'rounded-full h-10 flex items-center justify-center shadow-lg transition-colors duration-300 pointer-events-auto touch-action-manipulation',
       isDarkMode ? 'bg-gray-800 text-gray-200 hover:bg-gray-700' : 'bg-white text-gray-800 hover:bg-gray-100'
     ]"
     :style="{ pointerEvents: 'auto', touchAction: 'manipulation' }"


### PR DESCRIPTION
## Summary
- keep TrendsButton same style as other nav icons by removing `w-10`

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c1a4a000832e9706b70ad79d7171