### PR TITLE
Fix overlay axes font

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -129,6 +129,10 @@ export default {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         ctx.save();
         ctx.translate(chartArea.left - sc.scrollLeft, 0);
+        const ChartJs = window.Chart;
+        if (ChartJs?.defaults?.font?.string) {
+          ctx.font = ChartJs.defaults.font.string;
+        }
         const textColor = props.isDarkMode ? '#e5e7eb' : '#1f2937';
         ctx.strokeStyle = textColor;
         ctx.fillStyle = textColor;


### PR DESCRIPTION
## Summary
- set overlay axes plugin font to Chart.js defaults

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c2b38ad4832e82dc99f71b4bf29b