### PR TITLE
Update chart watchers to async

### DIFF
--- a/src/components/RainfallSampleTrend.vue
+++ b/src/components/RainfallSampleTrend.vue
@@ -329,11 +329,11 @@ export default {
 
     watch(
       () => props.history,
-      () => {
+      async () => {
         if (chartInstance) {
           chartInstance.destroy();
         }
-        createChart();
+        await createChart();
         scrollToLatest();
       },
       { deep: true }
@@ -341,11 +341,11 @@ export default {
 
     watch(
       () => props.isDarkMode,
-      () => {
+      async () => {
         if (chartInstance) {
           chartInstance.destroy();
         }
-        createChart();
+        await createChart();
       }
     );
 


### PR DESCRIPTION
## Summary
- make RainfallSampleTrend watchers async
- create chart before scroll or theme redraw

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c47d4da4832eb15b170db82b983b