### PR TITLE
Add usePopupAnalytics composable

### DIFF
--- a/src/components/DataInfoPopup.vue
+++ b/src/components/DataInfoPopup.vue
@@ -53,12 +53,11 @@
 
 <script>
 import { toRef } from 'vue';
-import { usePopupManager } from '../composables/usePopupManager';
+import { usePopupAnalytics } from '../composables/usePopupAnalytics';
 import {
   track,
   EVENT_CLICK_DATA_INFO_BUTTON,
   EVENT_CLICK_OUTBOUND_LINK,
-  EVENT_OPEN_POPUP,
 } from '../services/analytics';
 import PopupContainer from './PopupContainer.vue';
 import PopupButton from './PopupButton.vue';
@@ -87,25 +86,11 @@ export default {
    * @returns {Object} Reactive bindings for the template.
    */
   setup(props) {
-    const { isOpen, togglePopup: baseToggle } = usePopupManager('data-info');
-
-    /**
-     * Toggle popup visibility and track analytics events.
-     */
-    const togglePopup = () => {
-      try {
-        const wasClosed = !isOpen.value;
-        baseToggle();
-        if (wasClosed) {
-          track(EVENT_OPEN_POPUP, { component: 'DataInfoPopup' });
-          track(EVENT_CLICK_DATA_INFO_BUTTON);
-        }
-      } catch (error) {
-        console.error('Error toggling DataInfoPopup:', error);
-        // Still toggle the popup even if tracking fails
-        baseToggle();
-      }
-    };
+    const { isOpen, togglePopup } = usePopupAnalytics(
+      'data-info',
+      'DataInfoPopup',
+      EVENT_CLICK_DATA_INFO_BUTTON
+    );
 
     /**
      * Track clicks on outbound links.

--- a/src/components/DonatePopup.vue
+++ b/src/components/DonatePopup.vue
@@ -37,12 +37,11 @@
 </template>
 
 <script>
-import { usePopupManager } from '../composables/usePopupManager';
+import { usePopupAnalytics } from '../composables/usePopupAnalytics';
 import {
   track,
   EVENT_CLICK_DONATE_BUTTON,
   EVENT_CLICK_OUTBOUND_LINK,
-  EVENT_OPEN_POPUP,
 } from '../services/analytics';
 import PopupContainer from './PopupContainer.vue';
 import PopupButton from './PopupButton.vue';
@@ -66,25 +65,11 @@ export default {
    * @returns {Object} Reactive bindings for the template.
    */
   setup() {
-    const { isOpen, togglePopup: baseToggle } = usePopupManager('donate');
-
-    /**
-     * Toggle popup visibility and log analytics events.
-     */
-    const togglePopup = () => {
-      try {
-        const wasClosed = !isOpen.value;
-        baseToggle();
-        if (wasClosed) {
-          track(EVENT_OPEN_POPUP, { component: 'DonatePopup' });
-          track(EVENT_CLICK_DONATE_BUTTON);
-        }
-      } catch (error) {
-        console.error('Error toggling DonatePopup:', error);
-        // Still toggle the popup even if tracking fails
-        baseToggle();
-      }
-    };
+    const { isOpen, togglePopup } = usePopupAnalytics(
+      'donate',
+      'DonatePopup',
+      EVENT_CLICK_DONATE_BUTTON
+    );
 
     /**
      * Track clicks on outbound donation links.

--- a/src/components/InfoPopup.vue
+++ b/src/components/InfoPopup.vue
@@ -45,8 +45,7 @@
 
 <script>
 import { onMounted } from 'vue';
-import { usePopupManager } from '../composables/usePopupManager';
-import { track, EVENT_OPEN_POPUP } from '../services/analytics';
+import { usePopupAnalytics } from '../composables/usePopupAnalytics';
 import PopupContainer from './PopupContainer.vue';
 import PopupButton from './PopupButton.vue';
 
@@ -69,26 +68,7 @@ export default {
    * @returns {Object} Reactive bindings for the template.
    */
   setup() {
-    const { isOpen, togglePopup: baseToggle } = usePopupManager('info');
-
-    /**
-     * Toggle popup visibility and optionally track an analytics event.
-     *
-     * @param {boolean} [trackEvent=true] - Whether to log the open event.
-     */
-    const togglePopup = (trackEvent = true) => {
-      try {
-        const wasClosed = !isOpen.value;
-        baseToggle();
-        if (wasClosed && trackEvent) {
-          track(EVENT_OPEN_POPUP, { component: 'InfoPopup' });
-        }
-      } catch (error) {
-        console.error('Error toggling InfoPopup:', error);
-        // Still toggle the popup even if tracking fails
-        baseToggle();
-      }
-    };
+    const { isOpen, togglePopup } = usePopupAnalytics('info', 'InfoPopup');
 
     onMounted(() => {
       try {

--- a/src/composables/usePopupAnalytics.js
+++ b/src/composables/usePopupAnalytics.js
@@ -1,0 +1,37 @@
+import { usePopupManager } from './usePopupManager';
+import { track, EVENT_OPEN_POPUP } from '../services/analytics';
+
+/**
+ * Manage popup visibility with integrated analytics tracking.
+ *
+ * @param {string} name - Unique popup identifier for usePopupManager.
+ * @param {string} component - Component name for analytics events.
+ * @param {string} [buttonEvent] - Optional analytics event for button clicks.
+ */
+export function usePopupAnalytics(name, component, buttonEvent) {
+  const { isOpen, togglePopup: baseToggle, closePopup } = usePopupManager(name);
+
+  /**
+   * Toggle popup visibility and track opening events.
+   *
+   * @param {boolean} [trackEvent=true] - Whether to log analytics events.
+   */
+  const togglePopup = (trackEvent = true) => {
+    try {
+      const wasClosed = !isOpen.value;
+      baseToggle();
+      if (wasClosed && trackEvent) {
+        track(EVENT_OPEN_POPUP, { component });
+        if (buttonEvent) {
+          track(buttonEvent);
+        }
+      }
+    } catch (error) {
+      console.error(`Error toggling ${component}:`, error);
+      // Ensure popup still toggles if tracking fails
+      baseToggle();
+    }
+  };
+
+  return { isOpen, togglePopup, closePopup };
+}


### PR DESCRIPTION
## Summary
- add `usePopupAnalytics` composable for popup state + analytics
- refactor `DataInfoPopup`, `InfoPopup`, and `DonatePopup` to use new composable

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc915afc832e9da2df82e70bbac3