### PR TITLE
Fix date selector overlap

### DIFF
--- a/src/components/DateScroller.vue
+++ b/src/components/DateScroller.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed bottom-[calc(4rem+env(safe-area-inset-bottom,0px))] left-1/2 transform -translate-x-1/2 z-30"
+    class="fixed bottom-[calc(6rem+env(safe-area-inset-bottom,0px))] left-1/2 transform -translate-x-1/2 z-[320]"
   >
     <div
       :class="[


### PR DESCRIPTION
## Summary
- ensure DateScroller appears above popup buttons

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68460894f9ec832e9ff01a2c7968766d