### PR TITLE
Fix Trends theme toggle layout

### DIFF
--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -44,7 +44,7 @@ onMounted(async () => {
 
 <template>
   <div class="min-h-screen bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-200">
-    <div class="max-w-screen-lg mx-auto px-4 py-6 text-center">
+    <div class="max-w-screen-lg mx-auto px-4 pt-16 pb-6 text-center">
       <!-- Theme toggle -->
       <ThemeToggleButton :isDarkMode="isDarkMode" />
 


### PR DESCRIPTION
## Summary
- adjust padding on the Trends page container so the theme toggle button no longer overlaps the title

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684608b1b498832e9ed41562e071ce60