### PR TITLE
Hide date scroller when a popup is visible

### DIFF
--- a/src/composables/usePopupManager.js
+++ b/src/composables/usePopupManager.js
@@ -4,6 +4,13 @@ import { ref, computed } from 'vue';
 const activePopup = ref(null);
 
 /**
+ * Reactive flag indicating if any popup is open.
+ * Other components can use this to react when a popup is visible.
+ * @type {import('vue').ComputedRef<boolean>}
+ */
+export const anyPopupOpen = computed(() => activePopup.value !== null);
+
+/**
  * Provides reactive open state management for popups.
  * Only one popup can be open at a time.
  * @param {string} name - Unique name for the popup using this composable

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -11,6 +11,7 @@ import DonatePopup from '../components/DonatePopup.vue';
 import TrendsButton from '../components/TrendsButton.vue';
 import ThemeToggleButton from '../components/ThemeToggleButton.vue';
 import { useStaticData } from '../composables/useStaticData';
+import { anyPopupOpen } from '../composables/usePopupManager';
 import { isDarkMode } from '../stores/theme';
 import { basePath } from '../utils/basePath';
 
@@ -76,7 +77,12 @@ watch(
     <ThemeToggleButton :isDarkMode="isDarkMode" />
 
     <div v-if="data && metadata">
-      <DateScroller :dates="availableDates" v-model="date" :isDarkMode="isDarkMode" />
+      <DateScroller
+        v-if="!anyPopupOpen"
+        :dates="availableDates"
+        v-model="date"
+        :isDarkMode="isDarkMode"
+      />
 
       <!-- Legends -->
       <div class="absolute top-2 left-2 z-10 space-y-2">


### PR DESCRIPTION
## Summary
- export `anyPopupOpen` from `usePopupManager`
- hide `DateScroller` component whenever a popup is open

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684612690fd0832e8e280e27b2e729e6