### PR TITLE
Fix trends page button overlap

### DIFF
--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -44,7 +44,7 @@ onMounted(async () => {
 
 <template>
   <div class="min-h-screen bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-200">
-    <div class="max-w-screen-lg mx-auto px-4 pt-16 pb-6 text-center">
+    <div class="max-w-screen-lg mx-auto px-4 pt-16 pb-24 text-center">
       <!-- Theme toggle -->
       <ThemeToggleButton :isDarkMode="isDarkMode" />
 


### PR DESCRIPTION
## Summary
- adjust bottom padding so the text isn't hidden by the back button on mobile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461299cb6c832e93fd11f42d5f001c