### PR TITLE
Fix theme toggle sticky behavior on trends

### DIFF
--- a/src/components/ThemeToggleButton.vue
+++ b/src/components/ThemeToggleButton.vue
@@ -1,8 +1,11 @@
 <template>
   <button
     @click="toggleDarkMode"
-    class="fixed top-4 right-4 z-50 w-10 h-10 rounded-full shadow-md flex items-center justify-center transition-colors duration-300"
-    :class="isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-800'"
+    class="w-10 h-10 rounded-full shadow-md flex items-center justify-center transition-colors duration-300"
+    :class="[
+      sticky ? 'fixed top-4 right-4 z-50' : '',
+      isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-800',
+    ]"
   >
     {{ isDarkMode ? '☀️' : '🌙' }}
   </button>
@@ -15,6 +18,10 @@ defineProps({
   isDarkMode: {
     type: Boolean,
     default: false,
+  },
+  sticky: {
+    type: Boolean,
+    default: true,
   },
 });
 </script>

--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -46,7 +46,7 @@ onMounted(async () => {
   <div class="min-h-screen bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-200">
     <div class="max-w-screen-lg mx-auto px-4 pt-16 pb-6 text-center">
       <!-- Theme toggle -->
-      <ThemeToggleButton :isDarkMode="isDarkMode" />
+      <ThemeToggleButton :isDarkMode="isDarkMode" :sticky="false" />
 
       <h1 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">
         Trends: Rainfall vs Water Quality


### PR DESCRIPTION
## Summary
- allow `ThemeToggleButton` to be optional sticky
- disable sticky toggle on the trends page

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684612b4f908832e8f5bf30579b5e030