### PR TITLE
Refine trends page spacing and sticky theme toggle

### DIFF
--- a/src/pages/trends.vue
+++ b/src/pages/trends.vue
@@ -44,9 +44,9 @@ onMounted(async () => {
 
 <template>
   <div class="min-h-screen bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-200">
-    <div class="max-w-screen-lg mx-auto px-4 pt-16 pb-24 text-center">
+    <div class="max-w-screen-lg mx-auto px-4 pt-14 pb-24 text-center">
       <!-- Theme toggle -->
-      <ThemeToggleButton :isDarkMode="isDarkMode" :sticky="false" />
+      <ThemeToggleButton :isDarkMode="isDarkMode" />
 
       <h1 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">
         Trends: Rainfall vs Water Quality


### PR DESCRIPTION
## Summary
- reduce top padding so chart content starts higher
- make theme toggle sticky in the corner

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684615b0b754832ea71fcf9c82c1b907