### PR TITLE
Optimize initial render by eliminating double redirect

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import App from './App.vue'
 import './index.css'
 import { initAnalytics, track } from './services/analytics'
 import { basePath } from './utils/basePath'
+import latestDate from './generated/latest-date.ts'
 
 // Pages
 import IndexPage from './pages/index.vue'
@@ -16,7 +17,8 @@ const base: string = `${basePath}/`
 const router: Router = createRouter({
   history: createWebHistory(base),
   routes: [
-    { path: '/', component: IndexPage },
+    { path: '/', redirect: `/${latestDate}` },
+    { path: '/index', component: IndexPage },
     { path: '/:date', component: DatePage },
     { path: '/trends', component: TrendsPage },
   ],


### PR DESCRIPTION
- Remove index page redirect in favor of direct router redirect
- Router now redirects '/' directly to latest date (/{latestDate})
- Eliminates unnecessary render cycle from index → latest date
- Improves perceived performance by reducing visual jumpiness
- Keeps index page available at '/index' for backward compatibility