### PR TITLE
Fix jarring white loading screen in dark mode

### DIFF
--- a/src/components/MapViewer.vue
+++ b/src/components/MapViewer.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="w-full h-full">
-    <div id="map" class="absolute inset-0"></div>
+  <div class="w-full h-full" :class="isDarkMode ? 'bg-gray-800' : 'bg-white'">
+    <div id="map" class="absolute inset-0" :class="isDarkMode ? 'bg-gray-800' : 'bg-white'"></div>
   </div>
 </template>
 

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,11 @@ a {
   z-index: 0;
 }
 
+/* Ensure map has proper background during loading in dark mode */
+.dark #map {
+  background-color: #1f2937; /* gray-800 */
+}
+
 /* Ensure Leaflet tiles display correctly */
 .leaflet-tile-pane {
   z-index: 0;

--- a/src/pages/[date].vue
+++ b/src/pages/[date].vue
@@ -113,7 +113,7 @@ watch(
       </div>
     </div>
 
-    <div v-else class="text-center h-screen flex items-center justify-center flex-col">
+    <div v-else class="text-center h-screen flex items-center justify-center flex-col" :class="isDarkMode ? 'bg-gray-800 text-gray-100' : 'bg-white text-gray-900'">
       <div v-if="loading" class="text-lg">Loading water quality data...</div>
       <div v-else-if="error" class="text-red-500">
         <p class="text-lg">Error: {{ error }}</p>


### PR DESCRIPTION
- Update data loading screen background to match dark theme (gray-800)
- Add dark background styling to map container during initialization
- Enhance CSS with dark mode map background rules
- Provides smoother loading experience without white flash

Fixes loading state backgrounds in:
- Data loading screen ([date].vue)
- Map container initialization (MapViewer.vue)
- CSS rules for consistent dark theme (index.css)